### PR TITLE
Fix the date formatting for answer results.

### DIFF
--- a/ResearchSuite/ResearchSuite/RSDDateCoder.swift
+++ b/ResearchSuite/ResearchSuite/RSDDateCoder.swift
@@ -33,58 +33,71 @@
 
 import Foundation
 
-/**
- `RSDDateCoder` is used to handle specifying date encoding/decoding. If the calendar components supported by this formatter only include a subset of all the components then only those components should be displayed in the UI.
- */
+/// `RSDDateCoder` is used to handle specifying date encoding/decoding. If the calendar components supported by
+/// this formatter only include a subset of all the components then only those components should be displayed
+/// in the UI.
 public protocol RSDDateCoder : Codable {
     
-    /**
-     Formatter to use for encoding the date.
-     */
-    var formatter: DateFormatter { get }
+    /// The formatter to use for encoding and decoding the result.
+    ///
+    /// - seealso: `RSDAnswerResultType`
+    var resultFormatter: DateFormatter { get }
     
-    /**
-     Calendar components that are included in this encoder.
-     */
+    /// Formatter to use for decoding dates used to set up a date range.
+    ///
+    /// - seealso: `RSDDateRangeObject`
+    var inputFormatter: DateFormatter { get }
+    
+    /// Calendar components that are included for this date range.
     var calendarComponents: Set<Calendar.Component> { get }
     
-    /**
-     The calendar used by this encoder when formatting a `DateComponents` object.
-     */
+    /// The calendar used by this date range when formatting a `DateComponents` object.
     var calendar: Calendar { get }
 }
 
 extension RSDDateCoder {
     
-    /**
-     Use the coder to encode a date as a string.
-     */
-    public func string(from date: Date) -> String? {
+    /// Use the coder to encode a date as a string.
+    ///
+    /// - parameters:
+    ///     - date:             The date to encode.
+    ///     - isResultCoding:   Should this value be encoded using the result formatter?
+    public func string(from date: Date, isResultCoding: Bool = false) -> String? {
+        let formatter = isResultCoding ? resultFormatter : inputFormatter
         return formatter.string(from: date)
     }
     
-    /**
-     Use the coder to encode date components as a string.
-     */
-    public func string(from dateComponents: DateComponents) -> String? {
+    /// Use the coder to encode date components as a string.
+    ///
+    /// - parameters:
+    ///     - dateComponents:   The date components to encode.
+    ///     - isResultCoding:   Should this value be encoded using the result formatter?
+    public func string(from dateComponents: DateComponents, isResultCoding: Bool = false) -> String? {
         guard let date = calendar.date(from: dateComponents)
             else {
                 return nil
         }
+        let formatter = isResultCoding ? resultFormatter : inputFormatter
         return formatter.string(from: date)
     }
     
-    /**
-     Use the coder to decode a date from a string.
-     */
-    public func date(from string: String) -> Date? {
+    /// Use the coder to decode a date from a string.
+    ///
+    /// - parameters:
+    ///     - string:           The string to decode.
+    ///     - isResultCoding:   Should this value be encoded using the result formatter?
+    public func date(from string: String, isResultCoding: Bool = false) -> Date? {
+        let formatter = isResultCoding ? resultFormatter : inputFormatter
         return formatter.date(from: string)
     }
     
-    /**
-     Use the coder to decode date components from a string.
-     */
-    public func dateComponents(from string: String) -> DateComponents? {
+    /// Use the coder to decode date components from a string.
+    ///
+    /// - parameters:
+    ///     - string:           The string to decode.
+    ///     - isResultCoding:   Should this value be encoded using the result formatter?
+    public func dateComponents(from string: String, isResultCoding: Bool = false) -> DateComponents? {
+        let formatter = isResultCoding ? resultFormatter : inputFormatter
         guard let date = formatter.date(from: string)
             else {
                 return nil
@@ -92,3 +105,4 @@ extension RSDDateCoder {
         return calendar.dateComponents(calendarComponents, from: date)
     }
 }
+

--- a/ResearchSuite/ResearchSuite/RSDFormStepDataSourceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDFormStepDataSourceObject.swift
@@ -589,9 +589,9 @@ open class RSDChoicePickerTableItemGroup : RSDInputFieldTableItemGroup {
         let aType: RSDAnswerResultType = answerType ?? {
             let baseType: RSDAnswerResultType.BaseType = inputField.dataType.defaultAnswerResultBaseType()
             let sequenceType: RSDAnswerResultType.SequenceType? = singleSelection ? nil : .array
-            let dateFormat: String? = (inputField.range as? RSDDateRange)?.dateCoder?.formatter.dateFormat
+            let dateFormatter: DateFormatter? = (inputField.range as? RSDDateRange)?.dateCoder?.resultFormatter
             let unit: String? = (inputField.range as? RSDDecimalRange)?.unit
-            return RSDAnswerResultType(baseType: baseType, sequenceType: sequenceType, dateFormat: dateFormat, unit: unit, sequenceSeparator: nil)
+            return RSDAnswerResultType(baseType: baseType, sequenceType: sequenceType, dateFormat: dateFormatter?.dateFormat, unit: unit, sequenceSeparator: nil)
         }()
         
         super.init(beginningRowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint, answerType: aType, defaultAnswer: defaultAnswer, textFieldOptions: textFieldOptions, items: items, formatter: formatter, pickerSource: choicePicker)
@@ -640,13 +640,13 @@ final class RSDDateTableItemGroup : RSDInputFieldTableItemGroup {
         
         var pickerSource: RSDPickerDataSource? = inputField as? RSDPickerDataSource
         var formatter: Formatter? = (inputField.range as? RSDRangeWithFormatter)?.formatter
-        var dateFormat: String?
+        var dateFormatter: DateFormatter?
         
         if let dateRange = inputField.range as? RSDDateRange {
             let (src, fmt) = dateRange.dataSource()
             pickerSource = pickerSource ?? src
             formatter = formatter ?? fmt
-            dateFormat = dateRange.dateCoder?.formatter.dateFormat
+            dateFormatter = dateRange.dateCoder?.resultFormatter
         } else {
             let dateFormatter = DateFormatter()
             dateFormatter.dateStyle = .short
@@ -655,7 +655,7 @@ final class RSDDateTableItemGroup : RSDInputFieldTableItemGroup {
             pickerSource = pickerSource ?? RSDDatePickerDataSourceObject(datePickerMode: .dateAndTime, minimumDate: nil, maximumDate: nil, minuteInterval: nil, dateFormatter: dateFormatter)
         }
         
-        let answerType = RSDAnswerResultType(baseType: .date, sequenceType: nil, dateFormat: dateFormat, unit: nil, sequenceSeparator: nil)
+        let answerType = RSDAnswerResultType(baseType: .date, sequenceType: nil, dateFormat: dateFormatter?.dateFormat, unit: nil, sequenceSeparator: nil)
         super.init(beginningRowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint, answerType: answerType, defaultAnswer: nil, textFieldOptions: nil, items: nil, formatter: formatter, pickerSource: pickerSource)
     }
 }
@@ -698,9 +698,9 @@ final class RSDMultipleComponentTableItemGroup : RSDInputFieldTableItemGroup {
     public init(beginningRowIndex: Int, inputField: RSDMultipleComponentInputField, uiHint: RSDFormUIHint) {
         
         let baseType: RSDAnswerResultType.BaseType = inputField.dataType.defaultAnswerResultBaseType()
-        let dateFormat: String? = (inputField.range as? RSDDateRange)?.dateCoder?.formatter.dateFormat
+        let dateFormatter: DateFormatter? = (inputField.range as? RSDDateRange)?.dateCoder?.resultFormatter
         let unit: String? = (inputField.range as? RSDDecimalRange)?.unit
-        let answerType = RSDAnswerResultType(baseType: baseType, sequenceType: .array, dateFormat: dateFormat, unit: unit, sequenceSeparator: inputField.separator)
+        let answerType = RSDAnswerResultType(baseType: baseType, sequenceType: .array, dateFormat: dateFormatter?.dateFormat, unit: unit, sequenceSeparator: inputField.separator)
         
         super.init(beginningRowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint, answerType: answerType, defaultAnswer: nil, textFieldOptions: nil, items: nil, formatter: nil, pickerSource: inputField)
     }

--- a/ResearchSuiteTestApp/ResearchSuiteTestApp/ViewController.swift
+++ b/ResearchSuiteTestApp/ResearchSuiteTestApp/ViewController.swift
@@ -37,6 +37,8 @@ import ResearchSuiteUI
 
 class ViewController: UIViewController, RSDTaskViewControllerDelegate {
 
+    
+
     @IBOutlet weak var textView: UITextView!
     
     override func viewDidLoad() {
@@ -51,7 +53,7 @@ class ViewController: UIViewController, RSDTaskViewControllerDelegate {
 
     @IBAction func runFooTask(_ sender: Any) {
         var taskInfo = RSDTaskInfoStepObject(with: "foo")
-        taskInfo.taskTransformer = RSDTaskResourceTransformerObject(resourceName: "TaskFoo")
+        taskInfo.taskTransformer = RSDResourceTransformerObject(resourceName: "TaskFoo")
         taskInfo.title = "Da Foo"
         taskInfo.subtitle = "In da house"
         taskInfo.icon = try! RSDImageWrapper(imageName: "activityIcon")
@@ -94,6 +96,18 @@ class ViewController: UIViewController, RSDTaskViewControllerDelegate {
     
     func taskViewController(_ taskViewController: (UIViewController & RSDTaskController), viewControllerFor taskInfo: RSDTaskInfoStep) -> (UIViewController & RSDStepController)? {
         return nil
+    }
+    
+    func taskViewController(_ taskViewController: (UIViewController & RSDTaskController), asyncActionControllerFor configuration: RSDAsyncActionConfiguration) -> RSDAsyncActionController? {
+        return nil
+    }
+    
+    func taskViewController(_ taskViewController: (UIViewController & RSDTaskController), readyToSave taskPath: RSDTaskPath) {
+        // do nothing
+    }
+    
+    func taskViewControllerShouldAutomaticallyForward(_ taskViewController: (UIViewController & RSDTaskController)) -> Bool {
+        return false
     }
 }
 

--- a/ResearchSuiteTestApp/ResearchSuiteTestApp/ViewController.swift
+++ b/ResearchSuiteTestApp/ResearchSuiteTestApp/ViewController.swift
@@ -37,8 +37,6 @@ import ResearchSuiteUI
 
 class ViewController: UIViewController, RSDTaskViewControllerDelegate {
 
-    
-
     @IBOutlet weak var textView: UITextView!
     
     override func viewDidLoad() {


### PR DESCRIPTION
Forgot that I started this refactor and broke the build.  The idea is that while the UI may wish to display only certain parts of a date (month/year, month/day, hour/minute), the result is easier to normalize if it just puts in a value that is timeOnly or dateOnly with a standardized format.