### PR TITLE
@#%$!

### DIFF
--- a/ResearchSuiteUI/ResearchSuiteUI.xcodeproj/project.pbxproj
+++ b/ResearchSuiteUI/ResearchSuiteUI.xcodeproj/project.pbxproj
@@ -726,7 +726,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "ResearchSuiteUI/iOS/Info-iOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.sagebase.ResearchSuiteUI-iOS";
 				PRODUCT_NAME = ResearchSuiteUI;
@@ -748,7 +748,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "ResearchSuiteUI/iOS/Info-iOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.sagebase.ResearchSuiteUI-iOS";
 				PRODUCT_NAME = ResearchSuiteUI;


### PR DESCRIPTION
The bad news: Xcode 9.2 put us in a Catch-22 situation. If ResearchSuiteUI targeted iOS 11, CRF Validation App would fail to archive because of a weird lipo error. If ResearchSuiteUI targeted 10.3, it would fail to build because Xcode 9.2 won’t allow named colors in asset libraries if you target a pre-11 iOS.

The good news is, I found out why CRF was failing when ResearchSuiteUI was targeted at 11—a build phase run script copied from an app that used Brain Baseline was stripping out unused architectures from all frameworks, not just the BBL one, and somehow that was leaving just the ResearchSuiteUI framework in a state that caused the error. So I just deleted that script and voilà, it archives with a deployment target of 11.0.